### PR TITLE
Improve memory history 6.x

### DIFF
--- a/packages/native/src/__tests__/createMemoryHistory.test.tsx
+++ b/packages/native/src/__tests__/createMemoryHistory.test.tsx
@@ -93,7 +93,10 @@ it('will not attempt to navigate beyond whatever browser history it is possible 
   expect(windowGoSpy).toHaveBeenCalledTimes(3);
 
   const item = history.get(0);
-  expect(window.history.state).toEqual({ id: item.id });
+  expect(window.history.state).toEqual({
+    id: item.id,
+    backup: [{ id: item.id, path: item.path }],
+  });
 
   // Next replace the state and verify the item we are replacing
   // has the same id but the path has changed
@@ -125,7 +128,10 @@ it('will not attempt to navigate beyond whatever browser history it is possible 
   expect(item.path).toBe('/route-one');
   expect(replacedItem.path).toBe('/route-three');
   expect(item.id).toEqual(replacedItem.id);
-  expect(window.history.state).toEqual({ id: replacedItem.id });
+  expect(window.history.state).toEqual({
+    id: replacedItem.id,
+    backup: [{ id: replacedItem.id, path: replacedItem.path }],
+  });
 
   // Push another item
   const mockStateFour: NavigationState = {
@@ -154,6 +160,19 @@ it('will not attempt to navigate beyond whatever browser history it is possible 
   history.push({ path: '/route-one', state: mockStateFour });
   expect(history.index).toBe(1);
   expect(history.get(0).path).toBe('/route-three');
+  const oldItem = history.get(0);
   const newItem = history.get(1);
-  expect(window.history.state).toEqual({ id: newItem.id });
+  expect(window.history.state).toEqual({
+    id: newItem.id,
+    backup: [
+      {
+        id: oldItem.id,
+        path: oldItem.path,
+      },
+      {
+        id: newItem.id,
+        path: newItem.path,
+      },
+    ],
+  });
 });

--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -5,7 +5,7 @@ type HistoryRecord = {
   // Unique identifier for this record to match it with window.history.state
   id: string;
   // Navigation state object for the history entry
-  state: NavigationState;
+  state?: NavigationState;
   // Path of the history entry
   path: string;
 };
@@ -32,9 +32,24 @@ export default function createMemoryHistory() {
       )
     );
   };
+
+  const currentId = window.history?.state?.id;
+
+  // If there is an id already that means the page was reloaded and there should be backup to recover history entries.
+  if (currentId) {
+    items = window.history.state.backup;
+    index = items.length - 1;
+  }
+
   // Pending callbacks for `history.go(n)`
   // We might modify the callback stored if it was interrupted, so we have a ref to identify it
   const pending: { ref: unknown; cb: (interrupted?: boolean) => void }[] = [];
+
+  // Save only the entries to the left (back)
+  // because the ones to the right (forward) aren't useful and let us avoid unnecessary logic.
+  // Don't save state in the backup.
+  const getStatelessItems = () =>
+    items.slice(0, index + 1).map((item) => ({ path: item.path, id: item.id }));
 
   const interrupt = () => {
     // If another history operation was performed we need to interrupt existing ones
@@ -94,8 +109,12 @@ export default function createMemoryHistory() {
       // We don't store state object in history.state because:
       // - browsers have limits on how big it can be, and we don't control the size
       // - while not recommended, there could be non-serializable data in state
-      window.history.pushState({ id }, '', path);
+      window.history.pushState({ id, backup: getStatelessItems() }, '', path);
       log();
+    },
+
+    updateState(state: NavigationState) {
+      items[index].state = state;
     },
 
     replace({ path, state }: { path: string; state: NavigationState }) {
@@ -124,7 +143,11 @@ export default function createMemoryHistory() {
         items[index] = { path, state, id };
       }
 
-      window.history.replaceState({ id }, '', pathWithHash);
+      window.history.replaceState(
+        { id, backup: getStatelessItems() },
+        '',
+        pathWithHash
+      );
       log();
     },
 
@@ -223,6 +246,12 @@ export default function createMemoryHistory() {
     // Here we normalize it so that only external changes (e.g. user pressing back/forward) trigger the listener
     listen(listener: () => void) {
       const onPopState = () => {
+        const id = window.history.state?.id;
+
+        if (id && !items.find((item) => item.id === id)) {
+          items.push({ path: location.pathname + location.search, id });
+        }
+
         // Fix createMemoryHistory.index variable's value
         // as it may go out of sync when navigating in the browser.
         index = this.index;

--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -203,12 +203,9 @@ export default function createMemoryHistory() {
         }, 100);
 
         const onPopState = () => {
-          const id = window.history.state?.id;
-          const currentIndex = items.findIndex((item) => item.id === id);
-
           // Fix createMemoryHistory.index variable's value
           // as it may go out of sync when navigating in the browser.
-          index = Math.max(currentIndex, 0);
+          index = this.index;
 
           const last = pending.pop();
 
@@ -226,6 +223,10 @@ export default function createMemoryHistory() {
     // Here we normalize it so that only external changes (e.g. user pressing back/forward) trigger the listener
     listen(listener: () => void) {
       const onPopState = () => {
+        // Fix createMemoryHistory.index variable's value
+        // as it may go out of sync when navigating in the browser.
+        index = this.index;
+
         if (pending.length) {
           // This was triggered by `history.go(n)`, we shouldn't call the listener
           return;

--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -14,6 +14,24 @@ export default function createMemoryHistory() {
   let index = 0;
   let items: HistoryRecord[] = [];
 
+  const log = () => {
+    console.log(
+      JSON.stringify(
+        {
+          index,
+          indexGetter: history.index,
+          items: items.map((item, i) => ({
+            selected: history.index === i ? '<<<<<<<' : undefined,
+            path: item.path,
+            id: item.id,
+            state: item.state?.key || null,
+          })),
+        },
+        null,
+        4
+      )
+    );
+  };
   // Pending callbacks for `history.go(n)`
   // We might modify the callback stored if it was interrupted, so we have a ref to identify it
   const pending: { ref: unknown; cb: (interrupted?: boolean) => void }[] = [];
@@ -77,6 +95,7 @@ export default function createMemoryHistory() {
       // - browsers have limits on how big it can be, and we don't control the size
       // - while not recommended, there could be non-serializable data in state
       window.history.pushState({ id }, '', path);
+      log();
     },
 
     replace({ path, state }: { path: string; state: NavigationState }) {
@@ -106,6 +125,7 @@ export default function createMemoryHistory() {
       }
 
       window.history.replaceState({ id }, '', pathWithHash);
+      log();
     },
 
     // `history.go(n)` is asynchronous, there are couple of things to keep in mind:
@@ -212,6 +232,7 @@ export default function createMemoryHistory() {
         }
 
         listener();
+        log();
       };
 
       window.addEventListener('popstate', onPopState);

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -352,6 +352,12 @@ export default function useLinking(
       const route = findFocusedRoute(state);
       const path = getPathForRoute(route, state);
 
+      // Sometimes the onStateChagne is called two times with the same state.
+      // If the previous state path and the current path are the same, do nothing.
+      if (previousState && path === findFocusedRoute(previousState)?.path) {
+        return;
+      }
+
       previousStateRef.current = state;
       pendingPopStatePathRef.current = undefined;
 

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -270,7 +270,13 @@ export default function useLinking(
         }
       } else {
         // if current path didn't return any state, we should revert to initial state
-        navigation.resetRoot(state);
+        navigation.resetRoot();
+      }
+
+      // If the record doesn't have saved state, update it with the current one.
+      // The states are lost after reloading the page.
+      if (record && !record.state) {
+        history.updateState(navigation.getRootState());
       }
     });
   }, [enabled, history, ref]);
@@ -386,10 +392,8 @@ export default function useLinking(
               // An existing entry for this path exists and it's less than current index, go back to that
               await history.go(nextIndex - currentIndex);
             } else {
-              // We couldn't find an existing entry to go back to, so we'll go back by the delta
-              // This won't be correct if multiple routes were pushed in one go before
-              // Usually this shouldn't happen and this is a fallback for that
-              await history.go(historyDelta);
+              // We couldn't find an existing entry to go back to, so we'll do a replace.
+              history.replace({ path, state });
             }
 
             // Store the updated state as well as fix the path if incorrect

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -356,13 +356,13 @@ export default function useLinking(
         state
       );
 
-      if (
-        previousFocusedState &&
-        focusedState &&
-        // We should only handle push/pop if path changed from what was in last `popstate`
-        // Otherwise it's likely a change triggered by `popstate`
-        path !== pendingPath
-      ) {
+      // We should only handle push/pop if path changed from what was in last `popstate`
+      // Otherwise it's likely a change triggered by `popstate`
+      if (path === pendingPath) {
+        return;
+      }
+
+      if (previousFocusedState && focusedState) {
         const historyDelta =
           (focusedState.history
             ? focusedState.history.length

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -266,7 +266,9 @@ export default function useLinking(
             navigation.resetRoot(state);
           }
         } else {
-          navigation.resetRoot(state);
+          // Using a partial state without the root key will make the saved states unusable
+          const key = navigation.getRootState().key;
+          navigation.resetRoot({ key, ...state });
         }
       } else {
         // if current path didn't return any state, we should revert to initial state

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -168,7 +168,7 @@ export default function StackRouter(options: StackRouterOptions) {
       return {
         stale: false,
         type: 'stack',
-        key: `stack-${nanoid()}`,
+        key: state.key || `stack-${nanoid()}`,
         index: routes.length - 1,
         routeNames,
         routes,


### PR DESCRIPTION
**Motivation**

This PR's motivation is to improve how history works on the web.

There are two main problems to solve with this PR.
1. The index could get out of sync. This could lead to losing the state of items in the `createMemoryHistory.tsx`. Simply updating in one place can fix that.
2. After reloading the page the information about items in history is lost. To prevent that I am saving information about all entries in the "back" direction without the state in the `window.history.state`. They are later loaded on the page refresh. 
3. The user can't use the`initialRoute` and push more than one route at once. This should be now possible since the default behavior if the state is not found in the memory history is now `replace` instead of `pop`


Note: There is a commit called `log history` that should be removed before merging. It's here only to make it easier to understand what is happening under the hood for the person that wants to test these changes

**Few use cases that this PR is fixing**

1. User going back and forth in the browser history. 

- Navigate a few times to build a stack like `{routes: [A, B, C, D]}`
- Go back and forth in using browser buttons

Before this PR the items array in the createMemoryHistory would at some point lose information about history. It would keep only one item.

This was caused because the index was desynchronized with the actual position.

2. Losing information about history after reloading the page
- Navigate a few times to build a stack like `{routes: [A, B, C]}`
- Reload the page when at the C screen.
- Try to navigate to A screen.

Before this PR the information about history was lost after reloading the page. The memoryHistory wouldn't go back to the A entry in the history because the items array doesn't have A saved. Now the information is kept after the reload.
